### PR TITLE
just to fail in a branching PR case

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,10 @@ commands:
                 git fetch -u origin ${FETCH_REFS}
                 git checkout "pr/${CIRCLE_PR_NUMBER}/merge"
             fi
+            if [[ -z  "${CIRCLE_PR_NUMBER}" ]]
+            then
+              exit 1
+            fi
             set +x
 jobs:
   dumb-build:
@@ -28,8 +32,8 @@ jobs:
     steps:
       - git-pr
       - run:
-          name: "FIXIT: Manipulated failure"
-          command: exit 1
+          name: "Manipulated failure"
+          command: exit 0
 
 workflows:
   version: 2


### PR DESCRIPTION
### The Setup

<img width="637" alt="Screen Shot 2021-02-22 at 18 09 57" src="https://user-images.githubusercontent.com/1774905/108693915-5e438100-7539-11eb-84ec-480183b60817.png">

1. Source branch [`fix-exit-code` results in a failed build](https://github.com/rochecirclecipoc/sampleCCI4PR/blob/fix-exit-code/.circleci/config.yml#L23-L25).
1. Target branch [`fix-cci-pr-number` results in a failed build](https://github.com/rochecirclecipoc/sampleCCI4PR/blob/fix-cci-pr-number/.circleci/config.yml#L33-L34).
1. Merged codes results in a success build.



### Expectation
Success build

### Outcome
A build is triggered by [the commits `#4ea66a6` from source branch](https://app.circleci.com/pipelines/github/rochecirclecipoc/sampleCCI4PR/30/workflows/c9c2f791-003e-4372-a586-f2274019c163/jobs/30) and failed†. 

†_In order to view the project CircleCI dashboard, join the CircleCI project by clicking the invatation [link](https://app.circleci.com/pipelines/github/rochecirclecipoc/sampleCCI4PR?invite=true)._